### PR TITLE
AI리뷰 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-s3": "^3.729.0",
         "@aws-sdk/s3-request-presigner": "^3.729.0",
         "@faker-js/faker": "^9.3.0",
+        "@google/generative-ai": "^0.21.0",
         "@nestjs/common": "^11.0.5",
         "@nestjs/config": "^4.0.0",
         "@nestjs/core": "^11.0.3",
@@ -1753,6 +1754,15 @@
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=9.0.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.21.0.tgz",
+      "integrity": "sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "#questions/*": "./dist/questions/*",
     "#requests/*": "./dist/requests/*",
     "#reviews/*": "./dist/reviews/*",
-    "#users/*": "./dist/users/*"
+    "#users/*": "./dist/users/*",
+    "#aiReviewSummary/*": "./dist/aiReviewSummary/*"
   },
   "scripts": {
     "build": "nest build",
@@ -46,6 +47,7 @@
     "@aws-sdk/client-s3": "^3.729.0",
     "@aws-sdk/s3-request-presigner": "^3.729.0",
     "@faker-js/faker": "^9.3.0",
+    "@google/generative-ai": "^0.21.0",
     "@nestjs/common": "^11.0.5",
     "@nestjs/config": "^4.0.0",
     "@nestjs/core": "^11.0.3",

--- a/prisma/migrations/20250212155458_add_ai_review_summary/migration.sql
+++ b/prisma/migrations/20250212155458_add_ai_review_summary/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "AIReviewSummary" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "summaryReview" TEXT NOT NULL,
+    "driverId" TEXT NOT NULL,
+
+    CONSTRAINT "AIReviewSummary_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AIReviewSummary_driverId_key" ON "AIReviewSummary"("driverId");
+
+-- CreateIndex
+CREATE INDEX "AIReviewSummary_createdAt_idx" ON "AIReviewSummary"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "AIReviewSummary" ADD CONSTRAINT "AIReviewSummary_driverId_fkey" FOREIGN KEY ("driverId") REFERENCES "Driver"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250212174913_rollback/migration.sql
+++ b/prisma/migrations/20250212174913_rollback/migration.sql
@@ -1,0 +1,43 @@
+/*
+  Warnings:
+
+  - The values [GAGNWON] on the enum `Area` will be removed. If these variants are still used in the database, this will fail.
+  - You are about to drop the `AIReviewSummary` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "Area_new" AS ENUM ('SEOUL', 'GYEONGGI', 'INCHEON', 'GANGWON', 'CHUNGBUK', 'CHUNGNAM', 'SEJONG', 'DAEJEON', 'JEONBUK', 'JEONNAM', 'GWANGJU', 'GYEONGBUK', 'GYEONGNAM', 'DAEGU', 'ULSAN', 'BUSAN', 'JEJU');
+ALTER TABLE "User" ALTER COLUMN "areas" TYPE "Area_new"[] USING ("areas"::text::"Area_new"[]);
+ALTER TABLE "Driver" ALTER COLUMN "availableAreas" TYPE "Area_new"[] USING ("availableAreas"::text::"Area_new"[]);
+ALTER TYPE "Area" RENAME TO "Area_old";
+ALTER TYPE "Area_new" RENAME TO "Area";
+DROP TYPE "Area_old";
+COMMIT;
+
+-- DropForeignKey
+ALTER TABLE "AIReviewSummary" DROP CONSTRAINT "AIReviewSummary_driverId_fkey";
+
+-- DropTable
+DROP TABLE "AIReviewSummary";
+
+-- CreateTable
+CREATE TABLE "aiReviewSummary" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "summaryReview" TEXT NOT NULL,
+    "driverId" TEXT NOT NULL,
+
+    CONSTRAINT "aiReviewSummary_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "aiReviewSummary_driverId_key" ON "aiReviewSummary"("driverId");
+
+-- CreateIndex
+CREATE INDEX "aiReviewSummary_createdAt_idx" ON "aiReviewSummary"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "aiReviewSummary" ADD CONSTRAINT "aiReviewSummary_driverId_fkey" FOREIGN KEY ("driverId") REFERENCES "Driver"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,12 +66,13 @@ model Driver {
   provider   String?
   providerId String?
 
-  reviews       Review[]
-  requests      Request[]
-  estimations   Estimation[]
-  likedUsers    User[]
-  questions     Question[]
-  notifications Notification[]
+  reviews         Review[]
+  requests        Request[]
+  estimations     Estimation[]
+  likedUsers      User[]
+  questions       Question[]
+  notifications   Notification[]
+  aiReviewSummary AIReviewSummary?
 }
 
 model MoveInfo {
@@ -201,6 +202,20 @@ model Notification {
   estimationId String?
   question     Question?   @relation(fields: [questionId], references: [id])
   questionId   String?
+
+  @@index([createdAt])
+}
+
+model AIReviewSummary {
+  id        String    @id @default(uuid())
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  deletedAt DateTime?
+
+  summaryReview String
+
+  driver   Driver @relation(fields: [driverId], references: [id])
+  driverId String @unique
 
   @@index([createdAt])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,7 +72,7 @@ model Driver {
   likedUsers      User[]
   questions       Question[]
   notifications   Notification[]
-  aiReviewSummary AIReviewSummary?
+  aiReviewSummary aiReviewSummary?
 }
 
 model MoveInfo {
@@ -206,7 +206,7 @@ model Notification {
   @@index([createdAt])
 }
 
-model AIReviewSummary {
+model aiReviewSummary {
   id        String    @id @default(uuid())
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
@@ -234,7 +234,7 @@ enum Area {
   SEOUL
   GYEONGGI
   INCHEON
-  GAGNWON
+  GANGWON
   CHUNGBUK
   CHUNGNAM
   SEJONG

--- a/src/aiReviewSummary/aiReviewSummary.controller.ts
+++ b/src/aiReviewSummary/aiReviewSummary.controller.ts
@@ -1,16 +1,30 @@
-import { Controller, Get, Param, Post } from '@nestjs/common';
+import { Controller, Get, HttpStatus, Param, Post } from '@nestjs/common';
 import { AiReviewSummaryService } from '#aiReviewSummary/aiReviewSummary.service.js';
+import { ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { AiReviewSummaryResponseDTO } from './types/aiReviewSummary.dto.js';
 
 @Controller('reviewSummary')
 export class AiReviewSummaryController {
   constructor(private readonly aiReviewSummaryService: AiReviewSummaryService) {}
 
   @Get(':driverId')
+  @ApiOperation({ summary: '기사의 요약된 AI리뷰 조회' })
+  @ApiParam({ name: 'driverId', description: '기사 ID', type: 'string' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: AiReviewSummaryResponseDTO,
+  })
   async getAiReviewSummary(@Param('driverId') driverId: string) {
     return this.aiReviewSummaryService.getAiReviewSummary(driverId);
   }
 
   @Post(':driverId')
+  @ApiOperation({ summary: '기사의 AI리뷰 생성/업데이트' })
+  @ApiParam({ name: 'driverId', description: '기사 ID', type: 'string' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: AiReviewSummaryResponseDTO,
+  })
   async generateAiReviewSummary(@Param('driverId') driverId: string) {
     return this.aiReviewSummaryService.generateAiReviewSummary(driverId);
   }

--- a/src/aiReviewSummary/aiReviewSummary.controller.ts
+++ b/src/aiReviewSummary/aiReviewSummary.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Param, Post } from '@nestjs/common';
+import { AiReviewSummaryService } from '#aiReviewSummary/aiReviewSummary.service.js';
+
+@Controller('reviewSummary')
+export class AiReviewSummaryController {
+  constructor(private readonly aiReviewSummaryService: AiReviewSummaryService) {}
+
+  @Get(':driverId')
+  async getAiReviewSummary(@Param('driverId') driverId: string) {
+    return this.aiReviewSummaryService.getAiReviewSummary(driverId);
+  }
+
+  @Post(':driverId')
+  async generateAiReviewSummary(@Param('driverId') driverId: string) {
+    return this.aiReviewSummaryService.generateAiReviewSummary(driverId);
+  }
+}

--- a/src/aiReviewSummary/aiReviewSummary.exception.ts
+++ b/src/aiReviewSummary/aiReviewSummary.exception.ts
@@ -1,0 +1,8 @@
+import ExceptionMessages from '#exceptions/exception.messages.js';
+import { NotFoundException } from '#exceptions/http.exception.js';
+
+export class AiReviewSummaryNotFoundException extends NotFoundException {
+  constructor() {
+    super(ExceptionMessages.AI_REVIEWS_SUMMARY_NOT_FOUND);
+  }
+}

--- a/src/aiReviewSummary/aiReviewSummary.module.ts
+++ b/src/aiReviewSummary/aiReviewSummary.module.ts
@@ -6,11 +6,13 @@ import { AiReviewSummaryService } from '#aiReviewSummary/aiReviewSummary.service
 import { AiReviewSummaryRepository } from '#aiReviewSummary/aiReviewSummary.repository.js';
 import { GoogleGeminiService } from '#global/ai-services/gemini.service.js';
 import { ReviewModule } from '#reviews/review.module.js';
+import { DriverModule } from '#drivers/driver.module.js';
+import { AiReviewSummaryScheduler } from './aiReviewSummary.scheduler.js';
 
 @Module({
-  imports: [DBModule, GuardModule, ReviewModule],
+  imports: [DBModule, GuardModule, ReviewModule, DriverModule],
   controllers: [AiReviewSummaryController],
-  providers: [AiReviewSummaryService, AiReviewSummaryRepository, GoogleGeminiService],
+  providers: [AiReviewSummaryService, AiReviewSummaryRepository, GoogleGeminiService, AiReviewSummaryScheduler],
   exports: [AiReviewSummaryRepository],
 })
 export class AiReviewSummaryModule {}

--- a/src/aiReviewSummary/aiReviewSummary.module.ts
+++ b/src/aiReviewSummary/aiReviewSummary.module.ts
@@ -1,0 +1,16 @@
+import { DBModule } from '#global/db.module.js';
+import { GuardModule } from '#guards/guard.module.js';
+import { Module } from '@nestjs/common';
+import { AiReviewSummaryController } from '#aiReviewSummary/aiReviewSummary.controller.js';
+import { AiReviewSummaryService } from '#aiReviewSummary/aiReviewSummary.service.js';
+import { AiReviewSummaryRepository } from '#aiReviewSummary/aiReviewSummary.repository.js';
+import { GoogleGeminiService } from '#global/ai-services/gemini.service.js';
+import { ReviewModule } from '#reviews/review.module.js';
+
+@Module({
+  imports: [DBModule, GuardModule, ReviewModule],
+  controllers: [AiReviewSummaryController],
+  providers: [AiReviewSummaryService, AiReviewSummaryRepository, GoogleGeminiService],
+  exports: [AiReviewSummaryRepository],
+})
+export class AiReviewSummaryModule {}

--- a/src/aiReviewSummary/aiReviewSummary.repository.ts
+++ b/src/aiReviewSummary/aiReviewSummary.repository.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '#global/prisma.service.js';
+import { IAiReviewSummaryRepository } from '#aiReviewSummary/interfaces/aiReviewSummary.repository.interface.js';
+
+@Injectable()
+export class AiReviewSummaryRepository implements IAiReviewSummaryRepository {
+  private readonly aiReviewSummary;
+  constructor(private readonly prisma: PrismaService) {
+    this.aiReviewSummary = prisma.aiReviewSummary;
+  }
+
+  async findByDriverId(driverId: string) {
+    return this.aiReviewSummary.findUnique({
+      where: { driverId },
+    });
+  }
+
+  async createOrUpdate(driverId: string, summaryReview: string) {
+    return this.prisma.aiReviewSummary.upsert({
+      where: { driverId },
+      update: { summaryReview },
+      create: { driverId, summaryReview },
+    });
+  }
+}

--- a/src/aiReviewSummary/aiReviewSummary.scheduler.ts
+++ b/src/aiReviewSummary/aiReviewSummary.scheduler.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AiReviewSummaryService } from './aiReviewSummary.service.js';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { DriverRepository } from '#drivers/driver.repository.js';
+
+@Injectable()
+export class AiReviewSummaryScheduler {
+  private readonly logger = new Logger(AiReviewSummaryScheduler.name);
+
+  constructor(
+    private readonly aiReviewSummaryService: AiReviewSummaryService,
+    private readonly driverRepository: DriverRepository,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async handleCron() {
+    this.logger.log('AI 리뷰 요약 작업 시작...');
+
+    const drivers = await this.driverRepository.findAllDriverIds();
+
+    if (!drivers.length) {
+      this.logger.warn('드라이버가 존재하지 않습니다. 작업을 종료합니다.');
+      return;
+    }
+
+    for (const { id } of drivers) {
+      try {
+        this.logger.log(`리뷰 요약 중: ${id}`);
+        await this.aiReviewSummaryService.generateAiReviewSummary(id);
+        this.logger.log(`리뷰 요약 완료: ${id}`);
+      } catch (error) {
+        this.logger.error(`리뷰 요약 실패: ${id}`, error.stack);
+      }
+    }
+
+    this.logger.log('AI 리뷰 요약 작업 완료.');
+  }
+}

--- a/src/aiReviewSummary/aiReviewSummary.service.ts
+++ b/src/aiReviewSummary/aiReviewSummary.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { IAiReviewSummaryService } from '#aiReviewSummary/interfaces/aiReviewSummary.service.interface.js';
+import { AiReviewSummaryRepository } from '#aiReviewSummary/aiReviewSummary.repository.js';
+import { ReviewRepository } from '#reviews/review.repository.js';
+import { GoogleGeminiService } from '#global/ai-services/gemini.service.js';
+import { AiReviewSummaryNotFoundException } from '#aiReviewSummary/aiReviewSummary.exception.js';
+import { ReviewNotFoundException } from '#reviews/review.exception.js';
+
+@Injectable()
+export class AiReviewSummaryService implements IAiReviewSummaryService {
+  constructor(
+    private readonly aiReviewSummaryRepository: AiReviewSummaryRepository,
+    private readonly reviewRepository: ReviewRepository,
+    private readonly googleGeminiService: GoogleGeminiService,
+  ) {}
+
+  async getAiReviewSummary(driverId: string) {
+    const summary = await this.aiReviewSummaryRepository.findByDriverId(driverId);
+    if (!summary) {
+      throw new AiReviewSummaryNotFoundException();
+    }
+    return summary;
+  }
+
+  async generateAiReviewSummary(driverId: string) {
+    // 특정 드라이버의 리뷰 가져오기
+    const reviews = await this.reviewRepository.findByDriverId(driverId);
+    console.log('reviewsreviewsreviews', reviews);
+    if (!reviews.length) {
+      throw new ReviewNotFoundException();
+    }
+
+    // AI 모델을 이용해 리뷰 요약 생성
+    const reviewTexts = reviews.map(review => review.comment).join('\n');
+    console.log('reviewTextsreviewTextsreviewTexts', reviewTexts);
+    const aiSummary = await this.googleGeminiService.summarizeReviews(reviewTexts);
+    console.log('aiSummaryaiSummaryaiSummary', aiSummary);
+
+    // AI 요약 저장 (기존 데이터 있으면 업데이트)
+    return this.aiReviewSummaryRepository.createOrUpdate(driverId, aiSummary);
+  }
+}

--- a/src/aiReviewSummary/aiReviewSummary.service.ts
+++ b/src/aiReviewSummary/aiReviewSummary.service.ts
@@ -23,20 +23,15 @@ export class AiReviewSummaryService implements IAiReviewSummaryService {
   }
 
   async generateAiReviewSummary(driverId: string) {
-    // 특정 드라이버의 리뷰 가져오기
     const reviews = await this.reviewRepository.findByDriverId(driverId);
-    console.log('reviewsreviewsreviews', reviews);
     if (!reviews.length) {
       throw new ReviewNotFoundException();
     }
 
-    // AI 모델을 이용해 리뷰 요약 생성
     const reviewTexts = reviews.map(review => review.comment).join('\n');
-    console.log('reviewTextsreviewTextsreviewTexts', reviewTexts);
-    const aiSummary = await this.googleGeminiService.summarizeReviews(reviewTexts);
-    console.log('aiSummaryaiSummaryaiSummary', aiSummary);
 
-    // AI 요약 저장 (기존 데이터 있으면 업데이트)
+    const aiSummary = await this.googleGeminiService.summarizeReviews(reviewTexts);
+
     return this.aiReviewSummaryRepository.createOrUpdate(driverId, aiSummary);
   }
 }

--- a/src/aiReviewSummary/interfaces/aiReviewSummary.controller.interface.ts
+++ b/src/aiReviewSummary/interfaces/aiReviewSummary.controller.interface.ts
@@ -1,0 +1,6 @@
+import { IAiReviewSummary } from '../types/aiReviewSummary.types.js';
+
+export interface IAiReviewSummaryController {
+  getAiReviewSummary: (driverId: string) => Promise<IAiReviewSummary>;
+  generateAiReviewSummary: (driverId: string) => Promise<IAiReviewSummary>;
+}

--- a/src/aiReviewSummary/interfaces/aiReviewSummary.repository.interface.ts
+++ b/src/aiReviewSummary/interfaces/aiReviewSummary.repository.interface.ts
@@ -1,0 +1,6 @@
+import { IAiReviewSummary } from '../types/aiReviewSummary.types.js';
+
+export interface IAiReviewSummaryRepository {
+  findByDriverId: (driverId: string) => Promise<IAiReviewSummary>;
+  createOrUpdate: (driverId: string, summaryReview: string) => Promise<IAiReviewSummary>;
+}

--- a/src/aiReviewSummary/interfaces/aiReviewSummary.service.interface.ts
+++ b/src/aiReviewSummary/interfaces/aiReviewSummary.service.interface.ts
@@ -1,0 +1,6 @@
+import { IAiReviewSummary } from '#aiReviewSummary/types/aiReviewSummary.types.js';
+
+export interface IAiReviewSummaryService {
+  getAiReviewSummary: (driverId: string) => Promise<IAiReviewSummary>;
+  generateAiReviewSummary: (driverId: string) => Promise<IAiReviewSummary>;
+}

--- a/src/aiReviewSummary/types/aiReviewSummary.dto.ts
+++ b/src/aiReviewSummary/types/aiReviewSummary.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AiReviewSummaryResponseDTO {
+  @ApiProperty({ description: '이사정보 ID', type: String })
+  id: string;
+
+  @ApiProperty({ description: '작성 날짜', type: String, format: 'date-time' })
+  createdAt: Date;
+
+  @ApiProperty({ description: '수정 날짜', type: String, format: 'date-time' })
+  updatedAt: Date;
+
+  @ApiProperty({ description: '삭제된 날짜', type: String, format: 'date-time' })
+  deletedAt: Date;
+
+  @ApiProperty({ description: '요약된 리뷰', type: String })
+  summaryReview: string;
+
+  @ApiProperty({ description: '드라이버 ID', type: String })
+  driverId: string;
+}

--- a/src/aiReviewSummary/types/aiReviewSummary.types.ts
+++ b/src/aiReviewSummary/types/aiReviewSummary.types.ts
@@ -1,0 +1,10 @@
+export interface IAiReviewSummary {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt?: Date;
+
+  summaryReview: string;
+
+  driverId: string;
+}

--- a/src/drivers/driver.repository.ts
+++ b/src/drivers/driver.repository.ts
@@ -160,4 +160,10 @@ export class DriverRepository implements IDriverRepository {
 
     return !!driver;
   }
+
+  async findAllDriverIds() {
+    return this.driver.findMany({
+      select: { id: true },
+    });
+  }
 }

--- a/src/drivers/interfaces/driver.repository.interface.ts
+++ b/src/drivers/interfaces/driver.repository.interface.ts
@@ -1,6 +1,6 @@
 import { ProviderCreateDTO } from '#auth/types/provider.types.js';
 import { SignUpDTO } from '#auth/types/sign.dto.js';
-import { DriverUpdateDTO } from '#drivers/types/driver.dto.js';
+import { DriverIdDTO, DriverUpdateDTO } from '#drivers/types/driver.dto.js';
 import { Driver } from '#drivers/types/driver.types.js';
 import { DriversFindOptions } from '#types/options.type.js';
 
@@ -15,4 +15,5 @@ export interface IDriverRepository {
   delete: (id: string) => void;
   like: (driverId: string, userId: string) => Promise<Driver>;
   unlike: (driverId: string, userId: string) => Promise<Driver>;
+  findAllDriverIds: () => Promise<DriverIdDTO>;
 }

--- a/src/drivers/types/driver.dto.ts
+++ b/src/drivers/types/driver.dto.ts
@@ -11,6 +11,11 @@ export class DriversListDTO {
   list: FilteredDriverOutputDTO[];
 }
 
+export class DriverIdDTO {
+  @ApiProperty({ description: '기사 ID' })
+  id: string[];
+}
+
 const omitKeys = [...modelBaseKeys, ...sensitiveKeys] as (keyof DriverEntity)[];
 export class DriverPatchDTO extends PartialType(OmitType(DriverEntity, omitKeys)) {}
 export interface DriverUpdateDTO extends Partial<Omit<Driver, keyof ModelBase>> {}

--- a/src/exceptions/exception.messages.ts
+++ b/src/exceptions/exception.messages.ts
@@ -35,6 +35,7 @@ enum ExceptionMessages {
 
   REVIEW_NOT_FOUND = '찾을 수 없는 리뷰입니다.',
   REVIEW_ALREADY_SUBMITTED = '이미 리뷰를 작성하였습니다.',
+  AI_REVIEWS_SUMMARY_NOT_FOUND = 'AI 리뷰 요약이 존재하지 않습니다.',
 
   REQUEST_NOT_FOUND = '찾을 수 없는 지정견적요청입니다.',
   ALREADY_REQUESTED = '이미 지정견적요청을 하였습니다.',

--- a/src/global/ai-services/gemini.service.ts
+++ b/src/global/ai-services/gemini.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+@Injectable()
+export class GoogleGeminiService {
+  private genAI: GoogleGenerativeAI;
+
+  constructor() {
+    this.genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+  }
+
+  async summarizeReviews(reviews: string) {
+    const model = this.genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
+
+    const result = await model.generateContent({
+      contents: [{ role: 'user', parts: [{ text: `다음 리뷰들을 종합해서 간결하고 자연스럽게 요약해줘:\n\n${reviews}` }] }],
+    });
+
+    const response = await result.response.text();
+
+    return response || '요약 실패';
+  }
+}

--- a/src/global/app.module.ts
+++ b/src/global/app.module.ts
@@ -1,3 +1,4 @@
+import { AiReviewSummaryModule } from '#aiReviewSummary/aiReviewSummary.module.js';
 import { AuthModule } from '#auth/auth.module.js';
 import { nodeEnv } from '#configs/common.config.js';
 import jwtConfig from '#configs/jwt.config.js';
@@ -43,6 +44,7 @@ if (nodeEnv === 'development') {
     UserModule,
     SwaggerModule,
     StorageModule,
+    AiReviewSummaryModule,
     ConfigModule.forRoot({ isGlobal: true, load: [jwtConfig, postgresConfig], envFilePath: '.env' }),
     ScheduleModule.forRoot(),
   ],

--- a/src/reviews/review.module.ts
+++ b/src/reviews/review.module.ts
@@ -10,5 +10,6 @@ import { Module } from '@nestjs/common';
   imports: [DBModule, GuardModule, EstimationModule],
   controllers: [ReviewController],
   providers: [ReviewService, ReviewRepository],
+  exports: [ReviewRepository],
 })
 export class ReviewModule {}

--- a/src/reviews/review.repository.ts
+++ b/src/reviews/review.repository.ts
@@ -131,6 +131,12 @@ export class ReviewRepository implements IReviewRepository {
     return review;
   }
 
+  async findByDriverId(driverId: string) {
+    const review = await this.review.findMany({ where: { driverId } });
+
+    return review;
+  }
+
   async create(data: CreateReviewDTO) {
     const review = await this.prisma.$transaction(async tx => {
       const review = await tx.review.create({ data });

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -80,7 +80,7 @@ export type AreaType =
   | 'SEOUL'
   | 'GYEONGGI'
   | 'INCHEON'
-  | 'GAGNWON'
+  | 'GANGWON'
   | 'CHUNGBUK'
   | 'CHUNGNAM'
   | 'SEJONG'
@@ -99,7 +99,7 @@ export enum AreaTypeEnum {
   SEOUL = 'SEOUL',
   GYEONGGI = 'GYEONGGI',
   INCHEON = 'INCHEON',
-  GAGNWON = 'GAGNWON',
+  GANGWON = 'GANGWON',
   CHUNGBUK = 'CHUNGBUK',
   CHUNGNAM = 'CHUNGNAM',
   SEJONG = 'SEJONG',

--- a/src/utils/address-utils.ts
+++ b/src/utils/address-utils.ts
@@ -1,6 +1,6 @@
-import { Area } from '@prisma/client';
+import { AreaType } from '#types/common.types.js';
 
-export function areaToKeyword(area: Area): string {
+export function areaToKeyword(area: AreaType): string {
   switch (area) {
     case 'SEOUL':
       return '서울';
@@ -8,7 +8,7 @@ export function areaToKeyword(area: Area): string {
       return '경기';
     case 'INCHEON':
       return '인천';
-    case 'GAGNWON':
+    case 'GANGWON':
       return '강원';
     case 'CHUNGBUK':
       return '충북';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
       "#requests/*": ["./src/requests/*"],
       "#reviews/*": ["./src/reviews/*"],
       "#users/*": ["./src/users/*"],
+      "#aiReviewSummary/*": ["./src/aiReviewSummary/*"],
       "#prisma/*": ["./prisma/*"]
     }
   },


### PR DESCRIPTION
## 이슈 번호

- close #177 

## 작업 사항 설명
구글 제미니를 활용하여 AI리뷰분석 구현 및 스케쥴러를 활용하여 매일 자정에 생성/업데이트 진행 구현

## 작업 사항

- [x] AI리뷰관련 스키마 테이블 추가
- [x] getAiReviewSummary(기사의 요약된 AI리뷰 조회) API 제작
- [x] generateAiReviewSummary(기사의 AI리뷰 생성/업데이트) API 제작
- [x] 스케쥴러 활용하여 기사의 AI리뷰 생성/업데이트 매일 자정에 실행되도록 구현

## 기타
